### PR TITLE
Add support for Psalm v5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,21 +8,46 @@ on:
     branches:
       - master
 
+env:
+  COMPOSER_FLAGS: "--ansi --no-interaction --no-progress"
+
+permissions:
+  contents: read
+
 jobs:
   build:
+    name: "Psalm ${{ matrix.psalm-version }}, PHP ${{ matrix.php-version }}"
+
     runs-on: ubuntu-latest
+
     strategy:
       matrix:
-        php: [8.0]
-
-    name: PHP ${{ matrix.php }}
+        php-version:
+          - 7.4
+          - 8.0
+          - 8.1
+        psalm-version:
+          - 4
+          - 5
 
     steps:
-    - uses: actions/checkout@v2
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
 
-    - name: Install dependencies
-      run: |
-        export COMPOSER_ROOT_VERSION=dev-master
-        composer install --no-interaction --no-progress  --no-suggest
-    - name: Run Tests
-      run: vendor/bin/phpunit
+      - name: "Setup PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+          tools: composer
+
+      - name: "Install dependencies for Psalm 4"
+        if: "matrix.psalm-version == 4"
+        run: "composer require ${{ env.COMPOSER_FLAGS }} vimeo/psalm:'4.x-dev' psalm/plugin-phpunit:dev-master"
+
+      - name: "Install dependencies for Psalm 5"
+        if: "matrix.psalm-version == 5"
+        run: "composer require ${{ env.COMPOSER_FLAGS }} vimeo/psalm:'5.x-dev' psalm/plugin-phpunit:dev-master"
+
+      - name: Run Tests
+        run: vendor/bin/phpunit

--- a/Plugin.php
+++ b/Plugin.php
@@ -309,7 +309,7 @@ class Plugin implements
 			if ( $code_location ) {
 				IssueBuffer::accepts(
 					new HookNotFound(
-						'Hook ' . $hook_name . ' not found',
+						'Hook "' . $hook_name . '" not found',
 						$code_location
 					),
 					$statements_source->getSuppressedIssues()
@@ -323,7 +323,7 @@ class Plugin implements
 			if ( $code_location ) {
 				IssueBuffer::accepts(
 					new HookNotFound(
-						'Hook ' . $hook_name . ' is a filter not an action',
+						'Hook "' . $hook_name . '" is a filter not an action',
 						$code_location
 					),
 					$statements_source->getSuppressedIssues()
@@ -337,7 +337,7 @@ class Plugin implements
 			if ( $code_location ) {
 				IssueBuffer::accepts(
 					new HookNotFound(
-						'Hook ' . $hook_name . ' is an action not a filter',
+						'Hook "' . $hook_name . '" is an action not a filter',
 						$code_location
 					),
 					$statements_source->getSuppressedIssues()

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
 		"php-stubs/wordpress-stubs": "^5.5",
 		"php-stubs/wordpress-globals": "^0.2.0",
 		"php-stubs/wp-cli-stubs": "^2.5",
-		"vimeo/psalm": "^4"
+		"vimeo/psalm": "^4.4 || ^5"
 	},
 	"require-dev": {
 		"humanmade/coding-standards": "^1.2",
 		"phpunit/phpunit": "^9.0",
-		"psalm/plugin-phpunit": "^0.15.1"
+		"psalm/plugin-phpunit": "^0.17"
 	},
 	"extra": {
 		"psalm" : {

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -3,7 +3,6 @@
 	xmlns="https://getpsalm.org/schema/config"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
-	totallyTyped="true"
 >
 	<projectFiles>
 		<file name="./test.php" />

--- a/test.php
+++ b/test.php
@@ -5,7 +5,7 @@ do_action( 'foo', true );
 add_filter( 'upload_dir', 'filter_upload_dir' );
 
 /**
- * @param array{basedir: string, baseurl: string, error: false|string, path: string, subdir: string, url: string} $dir
+ * @param  array{basedir: string, baseurl: string, error: false|string, path: string, subdir: string, url: string} $dir
  * @return array{basedir: string, baseurl: string, error: false|string, path: string, subdir: string, url: string}
  */
 function filter_upload_dir( array $dir ) : array {
@@ -13,7 +13,7 @@ function filter_upload_dir( array $dir ) : array {
 }
 
 add_filter( 'foo', function ( bool $post ) : void {
-	new WP_Post( new StdClass );
+	new WP_Post( new stdClass );
 }, 10, 2 );
 
 add_filter( 'admin_notices', function () {


### PR DESCRIPTION
This pull request continues what was started in #41 and should be merged first.

---

Currently, the dependency constraints target vimeo/psalm `^5@beta` and psalm/plugin-phpunit `dev-master`.

Fixed errors and warnings raised by Psalm.

@kkmuffme has [mentioned](https://github.com/humanmade/psalm-plugin-wordpress/pull/41#issuecomment-1293095342) they also have a Psalm v5 ready fork of this plugin, which I was not aware of when I started my version. I'm sharing my implementation for reference and can be replaced by theirs.